### PR TITLE
Fixing Iron Will to only apply to Escalated Daylight (bird)

### DIFF
--- a/src/app/models/marquise.ts
+++ b/src/app/models/marquise.ts
@@ -114,7 +114,7 @@ Taking a single hit with a building has no effect.
   public daylight() {
     let totalWarriors = 4;
     if (this.difficulty === 'Easy') { totalWarriors = 2; }
-    if (this.hasTrait('Iron Will')) { totalWarriors *= 2; }
+    if (this.hasTrait('Iron Will') && this.customData.currentSuit === 'bird') { totalWarriors *= 2; }
 
     const blitzText = this.hasTrait('Blitz')
     ? `Find the clearing you rule of the highest priority without any enemy pieces.


### PR DESCRIPTION
The current code was applying the Iron Will trait to all recruits, when it should only apply to Escalated Daylight.